### PR TITLE
Fix bootloader flashed word check

### DIFF
--- a/STM32F103C8T6_Bootloader/Core/Src/bootloader.c
+++ b/STM32F103C8T6_Bootloader/Core/Src/bootloader.c
@@ -85,7 +85,7 @@ void flashWord(uint32_t dataToFlash)
 			  address = APP2_START + Flashed_offset;
 		  status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, dataToFlash);
 		  flash_attempt++;
-	  }while(status != HAL_OK && flash_attempt < 10 && dataToFlash == readWord(address));
+	  }while(status != HAL_OK && flash_attempt < 10 && dataToFlash != readWord(address));
 	  if(status != HAL_OK)
 	  {
 		  CDC_Transmit_FS((uint8_t*)&"Flashing Error!\n", strlen("Flashing Error!\n"));


### PR DESCRIPTION
If I understand the purpose of the condition correctly then, I think it should contain the check if the data is not flashed yet. Because why should it check if the data has been flashed so it could be flashed there once more.